### PR TITLE
Fix static asset paths and API base fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,209 @@
+"""Simple web application to visualize bean dependency chains."""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict, deque
+from functools import partial
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler
+from pathlib import Path
+from socketserver import ThreadingTCPServer
+from typing import Dict, Iterable, List, Optional, Set
+from urllib.parse import parse_qs, urlparse
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_FILE = BASE_DIR / "iuap-apdoc-basedoc.json"
+
+
+def _normalize_dependency_list(raw: Optional[Iterable[str]]) -> List[str]:
+    """Return a clean list of dependency names without empty values."""
+    if not raw:
+        return []
+    return [item for item in raw if item]
+
+
+def load_graph() -> Dict[str, object]:
+    """Build graph information from the bean description file."""
+    if not DATA_FILE.exists():
+        raise FileNotFoundError(
+            f"Cannot find {DATA_FILE}. Please make sure the bean description JSON is available."
+        )
+
+    with DATA_FILE.open("r", encoding="utf-8") as handle:
+        bean_definitions = json.load(handle)
+
+    dependencies_map: Dict[str, List[str]] = {}
+    metadata_map: Dict[str, Dict[str, object]] = {}
+
+    for bean in bean_definitions:
+        name = bean.get("name")
+        if not name:
+            # Skip entries without a valid bean name.
+            continue
+        dependencies = _normalize_dependency_list(bean.get("dependencies"))
+        dependencies_map[name] = dependencies
+
+        metadata_map[name] = {
+            "name": name,
+            "type": bean.get("type", ""),
+            "scope": bean.get("scope", ""),
+            "categories": bean.get("categories", []),
+            "source": bean.get("source", ""),
+            "definitionSource": bean.get("definitionSource", ""),
+            "isAdditionalBean": bean.get("isAdditionalBean", False),
+        }
+
+    # Add placeholder nodes for dependencies that do not have their own definitions.
+    for bean_name, dependencies in list(dependencies_map.items()):
+        for dependency in dependencies:
+            dependencies_map.setdefault(dependency, [])
+            if dependency not in metadata_map:
+                metadata_map[dependency] = {
+                    "name": dependency,
+                    "type": "External or undefined bean",
+                    "scope": "unknown",
+                    "categories": [],
+                    "source": "Unknown",
+                    "definitionSource": "",
+                    "isAdditionalBean": False,
+                    "missing": True,
+                }
+
+    incoming_map: Dict[str, Set[str]] = defaultdict(set)
+    for bean_name, dependencies in dependencies_map.items():
+        for dependency in dependencies:
+            incoming_map[dependency].add(bean_name)
+        incoming_map.setdefault(bean_name, set())
+
+    nodes: Dict[str, Dict[str, object]] = {}
+    edges: List[Dict[str, str]] = []
+
+    for bean_name, dependencies in dependencies_map.items():
+        metadata = metadata_map.get(bean_name, {"name": bean_name})
+        node = {
+            "id": bean_name,
+            "label": bean_name,
+            "dependencies": list(dependencies),
+            "dependents": sorted(incoming_map.get(bean_name, set())),
+            "hasDependencies": bool(dependencies),
+            "dependentCount": len(incoming_map.get(bean_name, set())),
+            "isRoot": len(incoming_map.get(bean_name, set())) == 0,
+            "missing": metadata.get("missing", False),
+            "metadata": metadata,
+        }
+        nodes[bean_name] = node
+
+        for dependency in dependencies:
+            edges.append({"source": bean_name, "target": dependency})
+
+    roots = sorted(name for name, node in nodes.items() if node["isRoot"])
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "roots": roots,
+        "dependencies": dependencies_map,
+    }
+
+
+GRAPH = load_graph()
+
+
+def build_subgraph(root: Optional[str]) -> Dict[str, object]:
+    """Return the graph filtered to nodes reachable from the given root."""
+    if not root or root.lower() == "all":
+        return {
+            "nodes": list(GRAPH["nodes"].values()),
+            "edges": GRAPH["edges"],
+            "roots": GRAPH["roots"],
+        }
+
+    if root not in GRAPH["nodes"]:
+        raise KeyError(root)
+
+    visited: Set[str] = set()
+    queue: deque[str] = deque([root])
+
+    while queue:
+        current = queue.popleft()
+        if current in visited:
+            continue
+        visited.add(current)
+        for dependency in GRAPH["dependencies"].get(current, []):
+            if dependency not in visited:
+                queue.append(dependency)
+
+    nodes = [GRAPH["nodes"][name] for name in visited]
+    edges = [edge for edge in GRAPH["edges"] if edge["source"] in visited and edge["target"] in visited]
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "roots": GRAPH["roots"],
+        "selectedRoot": root,
+    }
+
+
+class GraphRequestHandler(SimpleHTTPRequestHandler):
+    """HTTP request handler serving the visualization assets and data."""
+
+    def do_GET(self) -> None:  # noqa: N802 (method name is required by base class)
+        parsed_url = urlparse(self.path)
+        if parsed_url.path == "/graph-data":
+            params = parse_qs(parsed_url.query)
+            root = params.get("root", [None])[0]
+            try:
+                payload = build_subgraph(root)
+            except KeyError:
+                self.send_error(HTTPStatus.NOT_FOUND, f"Unknown bean '{root}'")
+                return
+
+            response = json.dumps(payload).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+            return
+
+        if parsed_url.path == "/roots":
+            response = json.dumps({"roots": GRAPH["roots"]}).encode("utf-8")
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+            return
+
+        if parsed_url.path == "/":
+            self.path = "/static/index.html"
+
+        return super().do_GET()
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003 (shadow builtins)
+        """Silence default logging to keep the console clean."""
+        # Comment out the next line to enable default logging.
+        return
+
+
+def serve(port: int) -> None:
+    """Start the HTTP server."""
+    handler = partial(GraphRequestHandler, directory=str(BASE_DIR))
+    with ThreadingTCPServer(("0.0.0.0", port), handler) as server:
+        print(f"Bean dependency visualizer available at http://localhost:{port}/")
+        print("Press Ctrl+C to stop.")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping server...")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Visualize bean dependency chains from a JSON file.")
+    parser.add_argument("--port", type=int, default=8000, help="Port to expose the web interface on.")
+    args = parser.parse_args()
+    serve(args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bean 依赖链路图</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+    <script defer src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+    <script defer src="/static/script.js"></script>
+  </head>
+  <body>
+    <header>
+      <h1>Bean 依赖链路图</h1>
+      <p>
+        该页面会根据 <code>iuap-apdoc-basedoc.json</code> 中的依赖信息，展示每个 Bean 的调用
+        链路。请选择一个最外层的起点 Bean 以加载对应的链路图，或者加载全部数据（数量较大时可能比较慢）。
+      </p>
+    </header>
+    <main>
+      <section class="controls">
+        <div class="control-group">
+          <label for="root-select">选择最外层端点：</label>
+          <select id="root-select">
+            <option value="" selected disabled>加载中…</option>
+          </select>
+          <button id="load-root" type="button">加载链路</button>
+          <button id="load-all" type="button">加载全部</button>
+        </div>
+        <div class="control-group">
+          <label for="search-input">在当前视图中查找 Bean：</label>
+          <input id="search-input" type="search" placeholder="输入 Bean 名称或关键字" />
+          <button id="reset-view" type="button">重置视图</button>
+        </div>
+        <div class="hint">
+          <span class="legend-color red"></span>
+          <span>红色节点表示没有依赖的 Bean；</span>
+          <span class="legend-color green"></span>
+          <span>绿色节点表示最外层端点。</span>
+        </div>
+        <div class="status" id="status-message">正在加载起点列表…</div>
+      </section>
+      <section class="content">
+        <div id="graph-container">
+          <svg id="graph" role="img" aria-label="Bean 依赖链路图"></svg>
+          <div id="graph-placeholder">请选择一个起点并点击“加载链路”。</div>
+        </div>
+        <aside id="info-panel">
+          <section id="stats">
+            <h2>当前数据统计</h2>
+            <p><strong>节点数：</strong><span id="stat-nodes">0</span></p>
+            <p><strong>依赖关系：</strong><span id="stat-edges">0</span></p>
+            <p><strong>起点数量：</strong><span id="stat-roots">0</span></p>
+          </section>
+          <section id="details">
+            <h2>节点详情</h2>
+            <p>点击图中的节点查看详细信息。</p>
+          </section>
+          <section id="legend">
+            <h2>图例</h2>
+            <ul>
+              <li><span class="legend-color red"></span> 无依赖的 Bean（链路终点），会被标红。</li>
+              <li><span class="legend-color green"></span> 最外层起点 Bean。</li>
+              <li><span class="legend-color blue"></span> 具有依赖的普通 Bean。</li>
+              <li><span class="legend-color gray"></span> JSON 中未给出定义的依赖（外部 Bean）。</li>
+            </ul>
+          </section>
+        </aside>
+      </section>
+    </main>
+    <footer>
+      <p>
+        使用鼠标滚轮缩放、拖拽背景进行平移，拖动节点以调整布局。当前页面使用 D3.js 绘制力导图，如需导出请使用浏览器的保存功能。
+      </p>
+    </footer>
+  </body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,489 @@
+const state = {
+  roots: [],
+  currentRoot: null,
+  graphData: null,
+  svg: null,
+  zoom: null,
+  simulation: null,
+  nodeSelection: null,
+  linkSelection: null,
+  labelSelection: null,
+  nodeById: new Map(),
+  highlightedNode: null,
+};
+
+const selectors = {
+  rootSelect: () => document.getElementById('root-select'),
+  loadRootButton: () => document.getElementById('load-root'),
+  loadAllButton: () => document.getElementById('load-all'),
+  searchInput: () => document.getElementById('search-input'),
+  resetViewButton: () => document.getElementById('reset-view'),
+  statusMessage: () => document.getElementById('status-message'),
+  placeholder: () => document.getElementById('graph-placeholder'),
+  statNodes: () => document.getElementById('stat-nodes'),
+  statEdges: () => document.getElementById('stat-edges'),
+  statRoots: () => document.getElementById('stat-roots'),
+  details: () => document.getElementById('details'),
+};
+
+const API_BASE = determineApiBase();
+const RUNNING_FROM_FILE = window.location.protocol === 'file:';
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupUI();
+  loadRoots();
+});
+
+function determineApiBase() {
+  const globalConfigBase = window.APP_CONFIG?.apiBase;
+  if (globalConfigBase) {
+    return globalConfigBase.replace(/\/+$/, '');
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const explicitBase = params.get('apiBase');
+  if (explicitBase) {
+    return explicitBase.replace(/\/+$/, '');
+  }
+
+  const portParam = params.get('port');
+  if (portParam) {
+    return `http://localhost:${portParam}`;
+  }
+
+  if (window.location.origin && window.location.origin !== 'null') {
+    return '';
+  }
+
+  return 'http://localhost:8000';
+}
+
+function buildApiUrl(path) {
+  if (!path.startsWith('/')) {
+    throw new Error('API path must start with a leading slash.');
+  }
+
+  if (!API_BASE) {
+    return path;
+  }
+
+  return `${API_BASE}${path}`;
+}
+
+function setupUI() {
+  selectors.loadRootButton().addEventListener('click', () => {
+    const select = selectors.rootSelect();
+    const root = select.value;
+    if (!root) {
+      setStatus('请选择一个最外层端点。', 'warn');
+      return;
+    }
+    loadGraph(root);
+  });
+
+  selectors.loadAllButton().addEventListener('click', () => {
+    loadGraph(null);
+  });
+
+  selectors.searchInput().addEventListener('input', handleSearch);
+  selectors.resetViewButton().addEventListener('click', resetView);
+}
+
+async function loadRoots() {
+  setStatus('正在加载起点列表…', 'info');
+  try {
+    const response = await fetch(buildApiUrl('/roots'));
+    if (!response.ok) {
+      throw new Error(`获取起点失败：${response.status}`);
+    }
+    const data = await response.json();
+    state.roots = data.roots || [];
+    populateRootSelect(state.roots);
+    if (state.roots.length) {
+      setStatus('请选择一个最外层端点并点击“加载链路”。', 'info');
+    } else {
+      setStatus('未在数据中找到起点。', 'warn');
+    }
+  } catch (error) {
+    console.error(error);
+    const rawBase = API_BASE || window.location.origin || 'http://localhost:8000';
+    const displayBase = !rawBase || rawBase === 'null' ? 'http://localhost:8000' : rawBase;
+    if (RUNNING_FROM_FILE) {
+      setStatus(
+        `加载起点列表失败。当前页面通过 file:// 打开，浏览器会阻止访问接口。请运行后端服务后在浏览器访问 ${displayBase}，` +
+          '如需指定端口，可在地址后加上 ?port=端口号。',
+        'error',
+      );
+    } else {
+      setStatus(`加载起点列表失败，请检查后端服务（${displayBase}）。`, 'error');
+    }
+  }
+}
+
+function populateRootSelect(roots) {
+  const select = selectors.rootSelect();
+  select.innerHTML = '';
+  if (!roots.length) {
+    const option = document.createElement('option');
+    option.textContent = '无可用起点';
+    option.disabled = true;
+    select.appendChild(option);
+    return;
+  }
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = '请选择一个起点';
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  select.appendChild(placeholder);
+
+  for (const root of roots) {
+    const option = document.createElement('option');
+    option.value = root;
+    option.textContent = root;
+    select.appendChild(option);
+  }
+}
+
+async function loadGraph(root) {
+  const rootLabel = root ? `起点 ${root}` : '全部节点';
+  setStatus(`正在加载 ${rootLabel} 的数据…`, 'info');
+
+  try {
+    const url = buildApiUrl(
+      root ? `/graph-data?root=${encodeURIComponent(root)}` : '/graph-data?root=all',
+    );
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`服务返回错误：${response.status}`);
+    }
+    const data = await response.json();
+    state.graphData = data;
+    state.currentRoot = root || null;
+    buildGraph(data);
+    updateStats(data);
+    setStatus(`已加载 ${rootLabel}，共 ${data.nodes.length} 个节点。`, 'success');
+  } catch (error) {
+    console.error(error);
+    setStatus('加载链路数据失败，请查看控制台日志。', 'error');
+  }
+}
+
+function buildGraph(data) {
+  const container = document.getElementById('graph-container');
+  const svg = d3.select('#graph');
+  svg.selectAll('*').remove();
+
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+  svg.attr('viewBox', [0, 0, width, height]);
+
+  if (!data.nodes.length) {
+    selectors.placeholder().textContent = '当前选择没有任何节点。';
+    selectors.placeholder().style.display = 'grid';
+    state.nodeSelection = null;
+    state.linkSelection = null;
+    state.labelSelection = null;
+    state.nodeById = new Map();
+    showDetails();
+    return;
+  }
+
+  selectors.placeholder().style.display = 'none';
+
+  if (state.simulation) {
+    state.simulation.stop();
+  }
+
+  const defs = svg.append('defs');
+  defs
+    .append('marker')
+    .attr('id', 'arrowhead')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 12)
+    .attr('refY', 0)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('d', 'M0,-5L10,0L0,5')
+    .attr('fill', '#9ca3af');
+
+  const g = svg.append('g');
+
+  const zoom = d3
+    .zoom()
+    .scaleExtent([0.1, 8])
+    .on('zoom', (event) => {
+      g.attr('transform', event.transform);
+    });
+  svg.call(zoom);
+  state.zoom = zoom;
+
+  const link = g
+    .append('g')
+    .attr('stroke', '#cbd5f5')
+    .attr('stroke-width', 1.1)
+    .selectAll('line')
+    .data(data.edges)
+    .join('line')
+    .attr('marker-end', 'url(#arrowhead)');
+
+  const nodeGroup = g.append('g');
+
+  const node = nodeGroup
+    .selectAll('g')
+    .data(data.nodes, (d) => d.id)
+    .join('g')
+    .call(
+      d3
+        .drag()
+        .on('start', (event, d) => {
+          if (!event.active) state.simulation.alphaTarget(0.3).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        })
+        .on('drag', (event, d) => {
+          d.fx = event.x;
+          d.fy = event.y;
+        })
+        .on('end', (event, d) => {
+          if (!event.active) state.simulation.alphaTarget(0);
+          d.fx = null;
+          d.fy = null;
+        })
+    );
+
+  node
+    .append('circle')
+    .attr('r', 8)
+    .attr('fill', nodeColor)
+    .attr('stroke', (d) => (d.isRoot && d.hasDependencies ? '#1b5e20' : '#1f2933'))
+    .attr('stroke-width', (d) => (d.isRoot && d.hasDependencies ? 2 : 1.2));
+
+  node
+    .append('title')
+    .text((d) => `${d.label}\n依赖数量：${d.dependencies.length}\n被依赖次数：${d.dependentCount}`);
+
+  node
+    .append('text')
+    .text((d) => d.label)
+    .attr('x', 12)
+    .attr('y', 4)
+    .attr('font-size', 11)
+    .attr('fill', '#1f2937')
+    .attr('pointer-events', 'none');
+
+  node.on('click', (_, d) => {
+    highlightNode(d.id);
+    showDetails(d);
+  });
+
+  state.simulation = d3
+    .forceSimulation(data.nodes)
+    .force(
+      'link',
+      d3
+        .forceLink(data.edges)
+        .id((d) => d.id)
+        .distance(90)
+        .strength(0.25)
+    )
+    .force('charge', d3.forceManyBody().strength(-220))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('collision', d3.forceCollide().radius(28));
+
+  state.simulation.on('tick', () => {
+    link
+      .attr('x1', (d) => d.source.x)
+      .attr('y1', (d) => d.source.y)
+      .attr('x2', (d) => d.target.x)
+      .attr('y2', (d) => d.target.y);
+
+    node.attr('transform', (d) => `translate(${d.x},${d.y})`);
+  });
+
+  state.svg = svg;
+  state.nodeSelection = node;
+  state.linkSelection = link;
+  state.labelSelection = node.select('text');
+  state.nodeById = new Map(data.nodes.map((n) => [n.id, n]));
+  state.highlightedNode = null;
+  highlightNode(null);
+  showDetails();
+}
+
+function nodeColor(node) {
+  if (!node.hasDependencies) {
+    return '#e53935';
+  }
+  if (node.missing) {
+    return '#6b7280';
+  }
+  if (node.isRoot) {
+    return '#2e7d32';
+  }
+  return '#1d4ed8';
+}
+
+function updateStats(data) {
+  selectors.statNodes().textContent = data.nodes.length.toLocaleString('zh-CN');
+  selectors.statEdges().textContent = data.edges.length.toLocaleString('zh-CN');
+  selectors.statRoots().textContent = (data.roots || []).length.toLocaleString('zh-CN');
+}
+
+function handleSearch() {
+  const term = selectors.searchInput().value.trim().toLowerCase();
+  if (!state.nodeSelection) {
+    return;
+  }
+
+  let firstMatch = null;
+  state.nodeSelection.select('circle').classed('matched', (d) => {
+    const match = term && d.id.toLowerCase().includes(term);
+    if (match && !firstMatch) {
+      firstMatch = d;
+    }
+    return match;
+  });
+
+  state.nodeSelection.select('text').classed('matched', (d) => term && d.id.toLowerCase().includes(term));
+
+  if (term && firstMatch) {
+    highlightNode(firstMatch.id, true);
+    showDetails(firstMatch);
+    setStatus(`找到匹配项：${firstMatch.id}`, 'success');
+  } else if (term) {
+    setStatus('未找到匹配的 Bean。', 'warn');
+  } else {
+    highlightNode(null);
+    setStatus('输入关键字以在当前视图中查找 Bean。', 'info');
+  }
+}
+
+function highlightNode(nodeId, center = false) {
+  if (!state.nodeSelection) {
+    return;
+  }
+
+  state.nodeSelection.classed('highlighted', (d) => d.id === nodeId);
+  state.nodeSelection.select('circle')
+    .attr('stroke-width', (d) => {
+      if (d.id === nodeId) {
+        return 3;
+      }
+      return d.isRoot && d.hasDependencies ? 2 : 1.2;
+    })
+    .attr('stroke', (d) => {
+      if (d.id === nodeId) {
+        return '#f59e0b';
+      }
+      return d.isRoot && d.hasDependencies ? '#1b5e20' : '#1f2933';
+    });
+
+  state.highlightedNode = nodeId;
+
+  if (center && nodeId && state.zoom && state.svg) {
+    const selected = state.nodeSelection.filter((d) => d.id === nodeId);
+    if (!selected.empty()) {
+      const datum = selected.datum();
+      const container = document.getElementById('graph-container');
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      const transform = d3.zoomIdentity
+        .translate(width / 2 - datum.x * 1.5, height / 2 - datum.y * 1.5)
+        .scale(1.5);
+      state.svg.transition().duration(500).call(state.zoom.transform, transform);
+    }
+  }
+}
+
+function showDetails(node) {
+  const details = selectors.details();
+  if (!node) {
+    details.innerHTML = '<h2>节点详情</h2><p>点击图中的节点查看详细信息。</p>';
+    return;
+  }
+
+  const meta = node.metadata || {};
+  const dependencies = node.dependencies || [];
+  const dependents = node.dependents || [];
+
+  details.innerHTML = `
+    <h2>节点详情</h2>
+    <p><strong>名称：</strong>${node.id}</p>
+    <p><strong>类型：</strong>${meta.type || '未知'}</p>
+    <p><strong>Scope：</strong>${meta.scope || '未知'}</p>
+    <p><strong>来源：</strong>${meta.source || '未知'}</p>
+    <p><strong>定义位置：</strong>${meta.definitionSource || '未知'}</p>
+    <p><strong>分类：</strong>${(meta.categories || []).join(', ') || '无'}</p>
+    <p><strong>是否附加 Bean：</strong>${meta.isAdditionalBean ? '是' : '否'}</p>
+    <p><strong>直接依赖 (${dependencies.length})：</strong></p>
+    ${renderRelationList(dependencies, 'dependency')}
+    <p><strong>被依赖 (${dependents.length})：</strong></p>
+    ${renderRelationList(dependents, 'dependent')}
+  `;
+}
+
+function renderRelationList(items, type) {
+  if (!items || !items.length) {
+    return '<p class="empty">无</p>';
+  }
+
+  const lis = items
+    .map((item) => {
+      const known = state.nodeById.has(item);
+      const button = known
+        ? `<button class="link" data-type="${type}" data-target="${item}">${item}</button>`
+        : `<span>${item}</span> (未在当前视图中)`;
+      return `<li>${button}</li>`;
+    })
+    .join('');
+
+  const listHtml = `<ul>${lis}</ul>`;
+
+  setTimeout(() => {
+    const detailPane = selectors.details();
+    detailPane.querySelectorAll('button.link').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const target = btn.getAttribute('data-target');
+        if (state.nodeById.has(target)) {
+          highlightNode(target, true);
+          showDetails(state.nodeById.get(target));
+        } else {
+          setStatus('该节点不在当前视图中，请加载相关起点。', 'warn');
+        }
+      });
+    });
+  }, 0);
+
+  return listHtml;
+}
+
+function resetView() {
+  selectors.searchInput().value = '';
+  highlightNode(null);
+  setStatus('视图已重置。', 'info');
+  if (state.svg && state.zoom) {
+    state.svg.transition().duration(500).call(state.zoom.transform, d3.zoomIdentity);
+  }
+}
+
+function setStatus(message, level = 'info') {
+  const el = selectors.statusMessage();
+  el.textContent = message;
+  el.dataset.level = level;
+}
+
+// Apply basic styling classes based on status level.
+const statusStyle = document.createElement('style');
+statusStyle.textContent = `
+  .status[data-level='info'] { color: #2563eb; }
+  .status[data-level='success'] { color: #16a34a; }
+  .status[data-level='warn'] { color: #d97706; }
+  .status[data-level='error'] { color: #dc2626; }
+  #graph text.matched { font-weight: 700; fill: #b91c1c; }
+  #graph circle.matched { stroke: #b91c1c !important; stroke-width: 2 !important; }
+`;
+document.head.appendChild(statusStyle);

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,274 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f7f9fc;
+  --panel-bg: #ffffffdd;
+  --border: #d0d7e2;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --accent: #2563eb;
+  --red: #e53935;
+  --green: #2e7d32;
+  --blue: #1d4ed8;
+  --gray: #6b7280;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+header {
+  padding: 1.5rem clamp(1rem, 4vw, 3rem);
+  background: linear-gradient(135deg, #e0f2fe, #f1f5f9);
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 2vw, 2.2rem);
+}
+
+header p {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem clamp(1rem, 4vw, 3rem);
+}
+
+.controls {
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  align-items: center;
+}
+
+.control-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.controls label {
+  font-weight: 600;
+}
+
+.controls select,
+.controls input,
+.controls button {
+  padding: 0.45rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+}
+
+.controls button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.controls button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(37, 99, 235, 0.2);
+}
+
+.controls input {
+  min-width: 200px;
+}
+
+.controls .hint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--muted);
+  flex-wrap: wrap;
+}
+
+.controls .status {
+  flex-basis: 100%;
+  color: var(--accent);
+}
+
+.content {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 1rem;
+  min-height: 0;
+}
+
+#graph-container {
+  position: relative;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  min-height: 480px;
+}
+
+#graph {
+  width: 100%;
+  height: 100%;
+}
+
+#graph-placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-size: 1rem;
+  pointer-events: none;
+}
+
+#info-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#info-panel section {
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+}
+
+#info-panel h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+#details p,
+#stats p {
+  margin: 0.4rem 0;
+  line-height: 1.5;
+}
+
+#details ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0.5rem 0 0;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+#details li {
+  margin-bottom: 0.25rem;
+}
+
+#details p.empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+#details button.link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+#details button.link:hover {
+  text-decoration: underline;
+}
+
+#legend ul {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.legend-color {
+  display: inline-block;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  margin-right: 0.35rem;
+  vertical-align: middle;
+}
+
+.legend-color.red {
+  background: var(--red);
+}
+
+.legend-color.green {
+  background: var(--green);
+}
+
+.legend-color.blue {
+  background: var(--blue);
+}
+
+.legend-color.gray {
+  background: var(--gray);
+}
+
+footer {
+  padding: 1rem clamp(1rem, 4vw, 3rem);
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+@media (max-width: 960px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  #info-panel {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  #info-panel section {
+    flex: 1 1 220px;
+  }
+}
+
+@media (max-width: 600px) {
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .control-group,
+  .controls .hint {
+    width: 100%;
+  }
+
+  .controls input {
+    min-width: unset;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- reference CSS and JavaScript assets with absolute /static paths so they load when visiting the root URL
- add configurable API base resolution with helpful messaging when the page is opened via file:// or when the backend is unreachable

## Testing
- python -m compileall app.py
- python - <<'PY'
import urllib.request, json
with urllib.request.urlopen('http://localhost:8123/roots') as resp:
    data = json.load(resp)
print(len(data['roots']))
print(data['roots'][:3])
PY

------
https://chatgpt.com/codex/tasks/task_e_68ccfad2d110832a8db9338f4a6b684f